### PR TITLE
fix to prevent loading the same page if it's already loading

### DIFF
--- a/Source/MoviesTableViewController.swift
+++ b/Source/MoviesTableViewController.swift
@@ -39,6 +39,7 @@ class MoviesTableViewController: UITableViewController, UISearchBarDelegate, UIS
     var displayedSearchId = -1
     var loadedPage: UInt = 0
     var nbPages: UInt = 0
+    var loadingPage: UInt = 0
     
     let placeholder = UIImage(named: "white")
     
@@ -121,6 +122,7 @@ class MoviesTableViewController: UITableViewController, UISearchBarDelegate, UIS
             
             self.displayedSearchId = curSearchId
             self.loadedPage = 0 // reset loaded page
+            self.loadingPage = 0 // reset the loading page
             
             let json = JSON(data!)
             let hits: [JSON] = json["hits"].arrayValue
@@ -144,6 +146,11 @@ class MoviesTableViewController: UITableViewController, UISearchBarDelegate, UIS
         if loadedPage + 1 >= nbPages {
             return
         }
+        // check if already loading this page so a redundent query isn't generated
+        if loadedPage + 1 == loadingPage {
+            return
+        }
+        loadingPage = loadedPage + 1
         
         let nextQuery = Query(copy: query)
         nextQuery.page = loadedPage + 1


### PR DESCRIPTION
There is a bug in the example where it will try to load the same page that it may already be querying resulting in redundant loads of the same page.  Since the loadMore check in cellForRowAtIndexPath looks ahead by 5 rows the same page can get loaded up to 5 additional times per page query.

You can see it hit the bug if you scroll really quickly or if you click on the search bar, scroll up a bit and then start typing a query with lots of results (like "the jungle book").  If the page boundary is fully visible you get all 5 extra queries per letter typed.  Around 83% of the queries are redundant.

The change is just to save the currently loading page and return if the same page is attempted.  Something more robust would probably be needed for a production implementation.
